### PR TITLE
fixed alignment for skill images

### DIFF
--- a/style.css
+++ b/style.css
@@ -165,10 +165,30 @@ h2, .project-buttons{
 }
 
 .about-imgs img{
-    max-width: 5%;
+    max-width: 9%;
     
 }
 
+.skills{
+    /* max-width: 100%; */
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 5%;
+    padding-left: 10%;
+    /* padding-right: 20%;  */
+}
+
+.skills img{
+    margin:10px
+}
+
+.row1, .row2{
+    display: flex;
+    justify-content: space-evenly;
+    align-items: center;
+    
+}
 
 
 


### PR DESCRIPTION
- skill images are spaced evenly and centered on the right side of the about page
- skill images are sized proportionately for good visibility and design
closes #5 