### PR TITLE
fixed about me image alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -159,8 +159,14 @@ h2, .project-buttons{
     justify-content: space-between;
 }
 
+.profile-pic{
+    width: 50%;
+    display: flex;
+    justify-content: center;
+}
+
 #hannah {
-    max-width: 30%;
+    max-width: 50%;
     width: 400px;
     height: auto;
     border-radius: 400px;
@@ -176,13 +182,12 @@ h2, .project-buttons{
 }
 
 .skills{
-    /* max-width: 100%; */
-    width: 100%;
+    width: 50%;
     display: flex;
     flex-direction: column;
     gap: 5%;
-    padding-left: 10%;
-    /* padding-right: 20%;  */
+    /* padding-left: 10%; */
+
 }
 
 .skills img{
@@ -195,8 +200,6 @@ h2, .project-buttons{
     align-items: center;
     
 }
-
-
 
 .projects-content{
     width: 100%;


### PR DESCRIPTION
- images in about me are aligned to headings and evenly spaced on either half of the screen
- alignment applies to different monitor sizes
update #19 